### PR TITLE
refactor: add migrations to change the host column to party_users

### DIFF
--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -1,4 +1,8 @@
 class Party < ApplicationRecord
   has_many :party_users
   has_many :users, through: :party_users
+
+  validates :movie_id, presence: true
+  validates :date, presence: true
+  validates :start_time, presence: true
 end

--- a/app/models/party_user.rb
+++ b/app/models/party_user.rb
@@ -1,4 +1,8 @@
 class PartyUser < ApplicationRecord
   belongs_to :party
   belongs_to :user
+
+  validates :user_id, presence: true
+  validates :party_id, presence: true
+  validates :is_host, inclusion: [true, false]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
   has_many :party_users
   has_many :parties, through: :party_users
+
+  validates :name, presence: true
+  validates :email, presence: true
 end

--- a/db/migrate/20231011201812_remove_host_id_from_parties.rb
+++ b/db/migrate/20231011201812_remove_host_id_from_parties.rb
@@ -1,0 +1,5 @@
+class RemoveHostIdFromParties < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :parties, :host_id
+  end
+end

--- a/db/migrate/20231011202051_add_is_host_to_party_users.rb
+++ b/db/migrate/20231011202051_add_is_host_to_party_users.rb
@@ -1,0 +1,5 @@
+class AddIsHostToPartyUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :party_users, :is_host, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_231849) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_11_202051) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,7 +18,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_231849) do
     t.integer "movie_id"
     t.date "date"
     t.time "start_time"
-    t.integer "host_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -28,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_231849) do
     t.bigint "party_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_host"
     t.index ["party_id"], name: "index_party_users_on_party_id"
     t.index ["user_id"], name: "index_party_users_on_user_id"
   end

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -5,4 +5,10 @@ RSpec.describe Party, type: :model do
     it {should have_many(:party_users)}
     it {should have_many(:users).through(:party_users)}
   end
+
+  describe "validations" do
+    it {should validate_presence_of :movie_id}
+    it {should validate_presence_of :date}
+    it {should validate_presence_of :start_time}
+  end
 end

--- a/spec/models/party_user_spec.rb
+++ b/spec/models/party_user_spec.rb
@@ -5,4 +5,10 @@ RSpec.describe PartyUser, type: :model do
     it {should belong_to(:user)}
     it {should belong_to(:party)}
   end
+
+  describe "validations" do
+    it {should validate_presence_of :user_id}
+    it {should validate_presence_of :party_id}
+    it {should validate_inclusion_of(:is_host).in_array([true, false])} # shoulda-matchers actually warns this is unnecessary, but it does pass of course
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,4 +5,9 @@ RSpec.describe User, type: :model do
     it {should have_many(:party_users)}
     it {should have_many(:parties).through(:party_users)}
   end
+
+  describe "validations" do
+    it {should validate_presence_of :name}
+    it {should validate_presence_of :email}
+  end
 end


### PR DESCRIPTION
#### Updates Made -
- User Stories Updated: N/A
- Database/Migrations: Remove `host_id` from Parties || Add `is_host` to party_users
- Routes: N/A
- Models: Add validations to parties, users, party_users
- Controllers: N/A
- Views: N/A
- Testing:
  - Models: Add validation testing to parties, users, party_users
  - Features: N/A
- Considerations(Extra notes, refactors, etc.): Having a test to validate the inclusion of true/false on the boolean column is being flagged by shoulda-matchers as not needed as it can't be "truly" tested since postgres will auto-convert values in that column to a boolean regardless. Left it in just for coverage.

