### PR TITLE
New viewing parties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,5 @@ group :test do
   gem "launchy"
   gem "simplecov"
   gem 'shoulda-matchers', '~> 5.0'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.3)
     diff-lcs (1.5.0)
@@ -97,6 +99,7 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -251,6 +254,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -282,6 +289,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/controllers/viewing_party_controller.rb
+++ b/app/controllers/viewing_party_controller.rb
@@ -1,6 +1,5 @@
 class ViewingPartyController < ApplicationController
   def new
-    # need to pass the JSON from TMDB so that I have the movie duration
     movie_id = params[:movie_id]
 
     conn = Faraday.new(url: "https://api.themoviedb.org") do |faraday|

--- a/app/controllers/viewing_party_controller.rb
+++ b/app/controllers/viewing_party_controller.rb
@@ -1,0 +1,14 @@
+class ViewingPartyController < ApplicationController
+  def new
+    # need to pass the JSON from TMDB so that I have the movie duration
+    movie_id = params[:movie_id]
+
+    conn = Faraday.new(url: "https://api.themoviedb.org") do |faraday|
+      faraday.params["api_key"] = Rails.application.credentials.tmdb[:key]
+    end
+
+    response = conn.get("/3/movie/#{movie_id}")
+
+    @movie = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/controllers/viewing_party_controller.rb
+++ b/app/controllers/viewing_party_controller.rb
@@ -14,6 +14,20 @@ class ViewingPartyController < ApplicationController
   end
 
   def create
-    require 'pry';binding.pry
+    party = Party.create(party_params)
+    guest_list = [params[:user_id].to_i]
+    params.select {|key, value| key.include?("invite") && value == "1"}
+      .each_key {|key| guest_list << key.gsub("invite-", "").to_i}
+
+    guest_list.each do |guest_id|
+      PartyUser.create(user_id: guest_id, party_id: party.id, is_host: guest_id == params[:user_id].to_i ? true : false)
+    end
+
+    redirect_to user_path(params[:user_id])
+  end
+
+  private
+  def party_params
+    params.permit(:movie_id, :date, :start_time, :duration)
   end
 end

--- a/app/controllers/viewing_party_controller.rb
+++ b/app/controllers/viewing_party_controller.rb
@@ -10,5 +10,10 @@ class ViewingPartyController < ApplicationController
     response = conn.get("/3/movie/#{movie_id}")
 
     @movie = JSON.parse(response.body, symbolize_names: true)
+    @users = User.all
+  end
+
+  def create
+    require 'pry';binding.pry
   end
 end

--- a/app/views/viewing_party/new.html.erb
+++ b/app/views/viewing_party/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with url: user_movie_viewing_party_index_path(params[:user_id], params[:movie_id]), method: :post, data: {turbo: false} do |f| %>
   <%= f.label :duration, "Duration of Party (in minutes):" %>
-  <%= f.number_field :duration, value: @movie[:runtime] %>
+  <%= f.number_field :duration, in: @movie[:runtime]..200, value: @movie[:runtime] %>
   <br>
   <%= f.label :date, "Date:" %>
   <%= f.date_field :date %>

--- a/app/views/viewing_party/new.html.erb
+++ b/app/views/viewing_party/new.html.erb
@@ -1,0 +1,22 @@
+<h1>Create a Viewing Party for "<%= @movie[:original_title] %>"</h1>
+
+<%= form_with url: user_movie_viewing_party_index_path(params[:user_id], params[:movie_id]), method: :post, data: {turbo: false} do |f| %>
+  <%= f.label :duration, "Duration of Party (in minutes):" %>
+  <%= f.number_field :duration, value: @movie[:runtime] %>
+  <br>
+  <%= f.label :date, "Date:" %>
+  <%= f.date_field :date %>
+  <br>
+  <%= f.label :start_time, "Start Time:" %>
+  <%= f.time_field :start_time %>
+  <br>
+  <p>Invite others:</p>
+  <br>
+  <% @users.each do |user| %>
+    <%= f.check_box "invite-#{user.id}" %>
+    <%= f.label "invite-#{user.id}", "#{user.email}" %>
+    <br>
+  <% end %>
+  <br>
+  <%= f.submit "Create Viewing Party" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   resources :users, only: [:show] do
     resources :discover, only: [:index]
+    resources :movies, only: [:show] do
+      resources :viewing_party, only: [:new, :create], path: '/viewing-party'
+    end
   end
 
 end

--- a/db/migrate/20231013003117_add_duration_to_parties.rb
+++ b/db/migrate/20231013003117_add_duration_to_parties.rb
@@ -1,0 +1,5 @@
+class AddDurationToParties < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_11_202051) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_13_003117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_202051) do
     t.time "start_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "duration"
   end
 
   create_table "party_users", force: :cascade do |t|

--- a/spec/features/viewing-party/new_spec.rb
+++ b/spec/features/viewing-party/new_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe "Viewing Party New page", type: :feature do
       @user_4 = User.create!(name: "Hiccup", email: "hiccupbird@gmail.com")
       @movie_id = 926393
 
-      visit new_user_movie_viewing_party(@user_1.id, @movie_id)
+      json_response = File.read('spec/fixtures/movie_details.json')
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{@movie_id}?api_key=#{Rails.application.credentials.tmdb[:key]}").
+        to_return(status: 200, body: json_response)
+
+      visit new_user_movie_viewing_party_path(@user_1.id, @movie_id)
     end
 
     it "I should see the name of the movie title" do
@@ -27,6 +31,10 @@ RSpec.describe "Viewing Party New page", type: :feature do
 
     it "The duration should default the value of the movie runtime in minutes" do
       expect(page).to have_field("duration", with: 109)
+    end
+
+    it "Should create a new viewing party and redirect the user to their dashboard on submit" do
+
     end
 
     xit "Should throw an error if the duration is less than the runtime of the movie" do

--- a/spec/features/viewing-party/new_spec.rb
+++ b/spec/features/viewing-party/new_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Viewing Party New page", type: :feature do
       expect(page).to have_field("duration", with: 109)
     end
 
-    it "Should create a new viewing party and redirect the user to their dashboard on submit" do
+    xit "Should create a new viewing party and redirect the user to their dashboard on submit" do
 
     end
 

--- a/spec/features/viewing-party/new_spec.rb
+++ b/spec/features/viewing-party/new_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "Viewing Party New page", type: :feature do
       page.has_field? "duration"
       page.has_field? "date"
       page.has_field? "start_time"
-      page.has_unchecked_field? @user_2.id
-      page.has_unchecked_field? @user_3.id
-      page.has_unchecked_field? @user_4.id
+      page.has_unchecked_field? "invite-#{@user_2.id}"
+      page.has_unchecked_field? "invite-#{@user_3.id}"
+      page.has_unchecked_field? "invite-#{@user_4.id}"
     end
 
     it "The duration should default the value of the movie runtime in minutes" do

--- a/spec/features/viewing-party/new_spec.rb
+++ b/spec/features/viewing-party/new_spec.rb
@@ -33,8 +33,13 @@ RSpec.describe "Viewing Party New page", type: :feature do
       expect(page).to have_field("duration", with: 109)
     end
 
-    xit "Should create a new viewing party and redirect the user to their dashboard on submit" do
+    it "Should create a new viewing party and redirect the user to their dashboard on submit" do
+      fill_in "date", with: "2023-10-10"
+      fill_in "start_time", with: "01:47:01"
+      click_button "Create Viewing Party"
 
+      expect(page).to have_current_path(user_path(@user_1.id))
+      expect(Party.last.start_time.strftime("%H:%M:%S")).to eq("01:47:01")
     end
 
     xit "Should throw an error if the duration is less than the runtime of the movie" do

--- a/spec/features/viewing-party/new_spec.rb
+++ b/spec/features/viewing-party/new_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe "Viewing Party New page", type: :feature do
+  describe "when I visit the viewing party new page" do
+    before(:each) do
+      @user_1 = User.create!(name: "Kiwi", email: "kiwibird@gmail.com")
+      @user_2 = User.create!(name: "Chicken", email: "chickenbird@gmail.com")
+      @user_3 = User.create!(name: "Coco", email: "cocobird@gmail.com")
+      @user_4 = User.create!(name: "Hiccup", email: "hiccupbird@gmail.com")
+      @movie_id = 926393
+
+      visit new_user_movie_viewing_party(@user_1.id, @movie_id)
+    end
+
+    it "I should see the name of the movie title" do
+      expect(page).to have_content("The Equalizer 3")
+    end
+
+    it "I should see a form below the movie title with the duration, when, start time, and checkboxes for each existing system user" do
+      page.has_field? "duration"
+      page.has_field? "date"
+      page.has_field? "start_time"
+      page.has_unchecked_field? @user_2.id
+      page.has_unchecked_field? @user_3.id
+      page.has_unchecked_field? @user_4.id
+    end
+
+    it "The duration should default the value of the movie runtime in minutes" do
+      expect(page).to have_field("duration", with: 109)
+    end
+
+    xit "Should throw an error if the duration is less than the runtime of the movie" do
+
+    end
+  end
+end

--- a/spec/features/viewing-party/new_spec.rb
+++ b/spec/features/viewing-party/new_spec.rb
@@ -42,8 +42,15 @@ RSpec.describe "Viewing Party New page", type: :feature do
       expect(Party.last.start_time.strftime("%H:%M:%S")).to eq("01:47:01")
     end
 
-    xit "Should throw an error if the duration is less than the runtime of the movie" do
+    it "Should create any associated invitations for a viewing party when the form is submitted" do
+      fill_in "date", with: "2023-10-10"
+      fill_in "start_time", with: "01:47:01"
+      check "invite-#{@user_2.id}"
+      click_button "Create Viewing Party"
 
+      expect(page).to have_current_path(user_path(@user_1.id))
+      expect(PartyUser.last.user_id).to eq(@user_2.id)
+      expect(PartyUser.last.is_host).to be false
     end
   end
 end

--- a/spec/fixtures/movie_details.json
+++ b/spec/fixtures/movie_details.json
@@ -1,0 +1,94 @@
+{
+  "adult": false,
+  "backdrop_path": "/cHNqobjzfLj88lpIYqkZpecwQEC.jpg",
+  "belongs_to_collection": {
+      "id": 523855,
+      "name": "The Equalizer Collection",
+      "poster_path": "/lq0Ledkl44xhnr1C15AiqbprAAi.jpg",
+      "backdrop_path": "/wac5llYhh0lC24yNWljrcOe4sR9.jpg"
+  },
+  "budget": 70000000,
+  "genres": [
+      {
+          "id": 28,
+          "name": "Action"
+      },
+      {
+          "id": 53,
+          "name": "Thriller"
+      },
+      {
+          "id": 80,
+          "name": "Crime"
+      },
+      {
+          "id": 18,
+          "name": "Drama"
+      }
+  ],
+  "homepage": "https://www.equalizer.movie",
+  "id": 926393,
+  "imdb_id": "tt17024450",
+  "original_language": "en",
+  "original_title": "The Equalizer 3",
+  "overview": "Robert McCall finds himself at home in Southern Italy but he discovers his friends are under the control of local crime bosses. As events turn deadly, McCall knows what he has to do: become his friends' protector by taking on the mafia.",
+  "popularity": 3197.13,
+  "poster_path": "/b0Ej6fnXAP8fK75hlyi2jKqdhHz.jpg",
+  "production_companies": [
+      {
+          "id": 1423,
+          "logo_path": "/1rbAwGQzrNvXDICD6HWEn1YqfAV.png",
+          "name": "Escape Artists",
+          "origin_country": "US"
+      },
+      {
+          "id": 5,
+          "logo_path": "/wrweLpBqRYcAM7kCSaHDJRxKGOP.png",
+          "name": "Columbia Pictures",
+          "origin_country": "US"
+      },
+      {
+          "id": 10400,
+          "logo_path": "/9LlB2YAwXTkUAhx0pItSo6pDlkB.png",
+          "name": "Eagle Pictures",
+          "origin_country": "IT"
+      },
+      {
+          "id": 44967,
+          "logo_path": null,
+          "name": "ZHIV Productions",
+          "origin_country": ""
+      }
+  ],
+  "production_countries": [
+      {
+          "iso_3166_1": "IT",
+          "name": "Italy"
+      },
+      {
+          "iso_3166_1": "US",
+          "name": "United States of America"
+      }
+  ],
+  "release_date": "2023-08-30",
+  "revenue": 167933602,
+  "runtime": 109,
+  "spoken_languages": [
+      {
+          "english_name": "English",
+          "iso_639_1": "en",
+          "name": "English"
+      },
+      {
+          "english_name": "Italian",
+          "iso_639_1": "it",
+          "name": "Italiano"
+      }
+  ],
+  "status": "Released",
+  "tagline": "Justice knows no borders.",
+  "title": "The Equalizer 3",
+  "video": false,
+  "vote_average": 7.4,
+  "vote_count": 701
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
#### Updates Made -
- User Stories Updated: #11 
- Database/Migrations: Add `duration` to `Parties`
- Routes: Resource :movies (:show) || Resource :viewing_parties (:new, :create)
- Models: N/A
- Controllers: Create ViewingPartyController with #new and #create actions
- Views: Create ViewingParty New page
- Testing:
  - Models: N/A
  - Features: Full feature testing for the new view, as well as creation of Parties and PartyUsers
- Considerations(Extra notes, refactors, etc.): The controller for the ViewingParties does have to have some pretty heavy ruby processing to handle the incoming parameters of selected checkboxes when creating a new party. I do think I have a way to slightly lessen it, but as far as I can tell there will always be some Ruby involvement.

Additionally, the following need to be implemented (I'll make a card for this): validate duration on backend (currently only front end validates), remove current user from invitation list, refactor to use facade/service/poros.

